### PR TITLE
nextvideo実行時、nullが返ってきた場合nextvideoを再実行するように

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -62,20 +62,26 @@
         }
       }
       function nextVideo() {
+        var nextVideoStatus = '';
         var xhr = new XMLHttpRequest();
-        xhr.open('GET', '/next?videoid=' + player.getVideoData().video_id);
-        xhr.onreadystatechange = function() {
-          if(xhr.readyState === 4 && xhr.status === 200) {
-            console.log(xhr.responseText);
-            if(xhr.responseText !== "") {
-              player.loadVideoById({videoId: xhr.responseText, startSeconds: 0});
+        while (true) {
+          xhr.open('GET', '/next?videoid=' + player.getVideoData().video_id);
+          xhr.onreadystatechange = function() {
+            if(xhr.readyState === 4 && xhr.status === 200) {
+              console.log(xhr.responseText);
+              if(xhr.responseText !== "") {
+                player.loadVideoById({videoId: xhr.responseText, startSeconds: 0});
+                nextVideoStatus = 'success';
+              } else {
+                nextVideoStatus = 'failed';
+              }
             }
-            if(xhr.responseText === "") {
-              $.ajax(this);
-            }
-            player.playVideoAt();
+          }
+          if (nextVideoStatus === 'success') {
+            break;
           }
         }
+        player.playVideoAt();
         xhr.send();
       }
       function stopVideo() {

--- a/views/index.erb
+++ b/views/index.erb
@@ -2,7 +2,7 @@
 <html>
   <body>
     <div id="player"></div>
-    <div>現在 <span id="cu">n</span> 人が見てるぽい</div>
+    <div>現在 <span id="cu">n</span> 人が見てるぽい</div>
     <script>
       var tag = document.createElement('script');
 
@@ -69,6 +69,9 @@
             console.log(xhr.responseText);
             if(xhr.responseText !== "") {
               player.loadVideoById({videoId: xhr.responseText, startSeconds: 0});
+            }
+            if(xhr.responseText === "") {
+              $.ajax(this);
             }
             player.playVideoAt();
           }


### PR DESCRIPTION
一人目
idが同じなのでキューの先頭を削除、抽選開始
二人目
一人目がidの先頭を消したので現在のidとnullを比較して違うと判断、nullを返す

という現象が発生しているようだ。
この問題を解決するため、もしnullが返ってきた場合にnextvideoを再実行する仕組みを実装したい。