### PR TITLE
除外できるようにしてみた

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ end
 namespace :db do
   desc "migrate db"
   task migrate: :environment do
-    DB = Sequel.sqlite("./db/breaktube-dev.db")
+    DB = Sequel.sqlite(ENV.fetch("DB_PATH","breaktube-prod.db"))
     Sequel.extension :migration
     Sequel::Migrator.run(DB, './db/migrations/', use_transactions: true)
   end

--- a/controllers/api.rb
+++ b/controllers/api.rb
@@ -173,16 +173,6 @@ module App
       ""
     end
 
-    get '/grid' do
-      @list = DataBase.new.all
-      erb :grid
-    end
-
-    get '/list' do
-      @list = DataBase.new.all
-      erb :list
-    end
-
     Thread.new do
       loop do
         sleep 15

--- a/controllers/html.rb
+++ b/controllers/html.rb
@@ -3,5 +3,24 @@ module App
     get '/' do
       erb :index
     end
+
+    get '/ignore' do
+      yid = params[:yid]
+      db = DataBase.new
+      db.ignore(yid)
+
+      @list = db.all
+      erb :list
+    end
+
+    get '/grid' do
+      @list = DataBase.new.all
+      erb :grid
+    end
+
+    get '/list' do
+      @list = DataBase.new.all
+      erb :list
+    end
   end
 end

--- a/db/migrations/004_create_ignorelists.rb
+++ b/db/migrations/004_create_ignorelists.rb
@@ -1,0 +1,13 @@
+
+Sequel.migration do
+  up do
+    create_table :ignorelists do
+      primary_key :id
+      String :youtube_id, null: false
+    end
+  end
+
+  down do
+    drop_table(:ignorelists)
+  end
+end

--- a/libs/database.rb
+++ b/libs/database.rb
@@ -36,7 +36,7 @@ class DataBase
   def rand_pick(range: 0)
     sql = DB[:playlists].reverse_order(:id)
     sql = sql.limit(range) if range != 0
-    sql.map(:youtube_id).sample
+    (sql.map(:youtube_id) - ignore_ids).sample
   end
 
   def short_video_pick
@@ -77,5 +77,13 @@ EOS
 
   def all
     DB[:playlists].select(:youtube_id, :user_name, :title_name, :playback_time).reverse_order(:id).map{ |s| s.values }
+  end
+
+  def ignore(yid)
+    DB[:ignorelists].insert(youtube_id: yid)
+  end
+
+  def ignore_ids
+    DB[:ignorelists].map(:youtube_id)
   end
 end

--- a/test/libs/test_database.rb
+++ b/test/libs/test_database.rb
@@ -66,6 +66,10 @@ class DatabaseTest < TestHelper
 
     DB[:playlists].insert(user_name: "user1", youtube_id: "BsB-7wZv_kI", title_name: "再生済", playback_time: 100, created_at: Time.now.to_i)
     assert_equal db.rand_pick(range: 1), "BsB-7wZv_kI"
+
+    DB[:ignorelists].insert(youtube_id: "PumFnlu9EIY")
+    DB[:ignorelists].insert(youtube_id: "o1jAMSQyVPc")
+    assert_equal db.rand_pick(range: 3), "BsB-7wZv_kI"
   end
 
   def test_short_video_pick
@@ -101,10 +105,26 @@ class DatabaseTest < TestHelper
     assert_equal db.all, [["o1jAMSQyVPc", "user2", "初音ミク「メルト」"], ["PumFnlu9EIY", "user1", "新・豪血寺一族 －煩悩開放－　レッツゴー！陰陽師　PV"]]
   end
 
+  def test_ignore
+    reset_db
+    assert_equal DB[:ignorelists].count, 0
+    db.ignore("o1jAMSQyVPc")
+    assert_equal DB[:ignorelists].count, 1
+  end
+
+  def ignore_ids
+    reset_db
+    DB[:ignorelists].insert(youtube_id: "o1jAMSQyVPc")
+    DB[:ignorelists].insert(youtube_id: "PumFnlu9EIY")
+
+    assert_equal db.ignore_ids, ["o1jAMSQyVPc", "PumFnlu9EIY"]
+  end
+
   private
   def reset_db
     DB[:playlists].delete
     DB[:finishlists].delete
+    DB[:ignorelists].delete
   end
 
   def db

--- a/views/list.erb
+++ b/views/list.erb
@@ -64,6 +64,7 @@
             <%= time %>
             <%= "@#{name}" %>
             <a href="https://www.youtube.com/watch?v=<%= yid %>" target="_blank" rel="noopener"><i class="fab fa-youtube text-danger"></i></a>
+            <a href="./ignore?yid=<%= yid %>" class="btn btn-outline-danger">除外する</a>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
とりあえず．
![image](https://user-images.githubusercontent.com/1211775/41164270-b38d30dc-6b75-11e8-9f04-ba659123a4e1.png)

list ページにこうでるので除外押す．
とりあえず除外リストは別

その前に migration が必要だけど
```
DB_PATH=db/breaktube-prod.db rake db:migrate
```
と DB パス指定できるようにしといた(デフォルトは root 上の breaktube-prod.db)ので必要であれば変更
![image](https://user-images.githubusercontent.com/1211775/41164332-e711db56-6b75-11e8-9f1b-6e01f3a8eabf.png)
既にテーブルあって migration できない，場合は
このテーブルを該当のところまで済みにするか，テーブル一旦リネームとかで．

多分動くはずだけど，力技なんでもうちょいなんとかしたい．